### PR TITLE
Cleanup Desmo module

### DIFF
--- a/src/lib/desmo-module.ts
+++ b/src/lib/desmo-module.ts
@@ -22,7 +22,6 @@ export class Desmo {
   private readonly callback: string = contractAddress;
   private readonly category: number;
   private dealId: string;
-  private taskId: string;
 
   /**
    *
@@ -53,7 +52,6 @@ export class Desmo {
 
     this.category = 0;
     this.dealId = '';
-    this.taskId = '';
   }
   /**
    * connect the desmo contract to the wallet
@@ -138,7 +136,7 @@ export class Desmo {
       throw new Error('A connection to iExec is required!');
     }
     const deal = await this.iexec.deal.show(this.dealId);
-    return (this.taskId = deal.tasks['0']);
+    return deal.tasks['0'];
   }
 
   private async retrieveCallbackAddress(): Promise<string> {

--- a/src/lib/desmo-module.ts
+++ b/src/lib/desmo-module.ts
@@ -130,8 +130,8 @@ export class Desmo {
     if (this.iexec === undefined) {
       throw new Error('A connection to iExec is required!');
     }
-    const deal = await this.iexec.deal.show(this.dealId);
-    return deal.tasks['0'];
+    const { tasks } = await this.iexec.deal.show(this.dealId);
+    return tasks[0];
   }
 
   private async retrieveCallbackAddress(): Promise<string> {

--- a/src/lib/desmo-module.ts
+++ b/src/lib/desmo-module.ts
@@ -103,12 +103,10 @@ export class Desmo {
       appAddress,
     );
 
-    const appOrder = appOrders && appOrders[0] && appOrders[0].order;
-
-    if (!appOrder) {
+    if (appOrders.length <= 0) {
       throw new Error(`no apporder found for app ${appAddress}`);
     } else {
-      return appOrder as AppOrder;
+      return appOrders[0].order as AppOrder;
     }
   }
 
@@ -121,13 +119,10 @@ export class Desmo {
         category: this.category,
       });
 
-    const workerpoolOrder =
-      workerpoolOrders && workerpoolOrders[0] && workerpoolOrders[0].order;
-
-    if (!workerpoolOrder) {
+    if (workerpoolOrders.length <= 0) {
       throw new Error(`no workerpoolorder found for category ${this.category}`);
     } else {
-      return workerpoolOrder as WorkerpoolOrder;
+      return workerpoolOrders[0].order as WorkerpoolOrder;
     }
   }
 

--- a/src/lib/desmo-module.ts
+++ b/src/lib/desmo-module.ts
@@ -103,7 +103,7 @@ export class Desmo {
       appAddress,
     );
 
-    if (appOrders.length <= 0) {
+    if (appOrders.length < 1) {
       throw new Error(`no apporder found for app ${appAddress}`);
     } else {
       return appOrders[0].order as AppOrder;
@@ -119,7 +119,7 @@ export class Desmo {
         category: this.category,
       });
 
-    if (workerpoolOrders.length <= 0) {
+    if (workerpoolOrders.length < 1) {
       throw new Error(`no workerpoolorder found for category ${this.category}`);
     } else {
       return workerpoolOrders[0].order as WorkerpoolOrder;
@@ -211,6 +211,7 @@ await desmoContract.buyQuery(
         volume: 1,
         params: requestID.toString() + ' ' + query,
         category: this.category,
+        // TODO: understand why the callback is needed and why the typing is wrong
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         callback: this.callback,


### PR DESCRIPTION
Assigned the correct type to the `iexec` member of the `Desmo` module and added checks against this possibly undefined variable.

As a result, since the `createRequestorder` function from the iExec SDK (the latest v7.2.1) expects an object that does not have the `callback` property, **a compilation error** inside the `buyQuery` method emerged and **needs to be addressed before accepting this Pull Request**.

**EDIT**: see #5 for information on how we chose to deal with the `callback` issue.