### PR TITLE
Refactor getQueryResult

### DIFF
--- a/src/lib/desmo-module.ts
+++ b/src/lib/desmo-module.ts
@@ -6,7 +6,7 @@
 
 import { contractAddress, abi as contractABI } from '../resources/desmo-config';
 
-import { AppOrder, TaskStatus, WorkerpoolOrder } from '../types/desmo-types';
+import { AppOrder, WorkerpoolOrder, TaskStatus } from '../types/desmo-types';
 
 import { ethers } from 'ethers';
 import { WalletSigner } from './walletSigner/walletSigner-module';
@@ -235,35 +235,51 @@ await desmoContract.buyQuery(
     taskId: string;
     result: string;
   }> {
-    const myIexec = this.iexec as IExec;
+    if (this.iexec === undefined) {
+      throw new Error('A connection to iExec is required!');
+    }
     if (!this.isConnected) {
       throw new Error(
         'This method requires the wallet signer to be already signed-in!',
       );
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const self = this;
-    return new Promise((resolve, reject) => {
-      (function loop(): void {
-        setTimeout(async () => {
-          const taskId = await self.retrieveTaskID();
-          const taskDetail = await myIexec.task.show(taskId);
-          console.log(
-            `The status of the task ${taskId} is ${taskDetail.statusName}`,
-          );
-          if (taskDetail.statusName === TaskStatus.COMPLETED) {
-            const tx = await self.contract.receiveResult(taskId, '0x00');
-            await tx.wait();
-            const result = await self.contract.getQueryResult(taskId);
-            // TODO: Decode the result
-            resolve({ requestId: '', taskId, result });
-          } else {
-            loop();
-          }
-        }, 1000);
-      })();
+    const taskId = await this.retrieveTaskID();
+
+    const taskObservable = await this.iexec.task.obsTask(taskId, {
+      dealid: this.dealId,
     });
+
+    const taskCompletion: Promise<ethers.Bytes> = new Promise(
+      (resolve, reject) => {
+        taskObservable.subscribe({
+          next: async ({ message }) => {
+            switch (message) {
+              case TaskStatus.TASK_COMPLETED:
+                {
+                  const tx = await this.contract.receiveResult(taskId, '0x00');
+                  await tx.wait();
+                  const result: ethers.Bytes =
+                    await this.contract.getQueryResult(taskId);
+                  resolve(result);
+                }
+                break;
+              case TaskStatus.TASK_FAILED:
+              case TaskStatus.TASK_TIMEDOUT:
+                {
+                  reject(`Task execution failed. Reason: ${message}.`);
+                }
+                break;
+            }
+          },
+          error: (e) => reject(e),
+        });
+      },
+    );
+
+    const result = await taskCompletion;
+    // TODO: Decode the result
+    return { requestId: '', taskId, result: result.toString() };
   }
 
   // TODO access a different source with the address

--- a/src/test/desmo-test.ts
+++ b/src/test/desmo-test.ts
@@ -34,24 +34,34 @@ describe('Desmo Tests', function () {
     desmohub.stopListeners();
   });
 
-  beforeEach((done) => setTimeout(done, 20000));
-
   describe('Buy query process', function () {
-    it('should buy a query', async () => {
+    it('should buy a query and retrieve its result', async () => {
       const eventPromise = firstValueFrom(desmohub.requestID$);
       await desmohub.getNewRequestID();
       const event: IRequestIDEvent = await eventPromise;
 
+      const query = {
+        prefixList: [
+          { abbreviation: 'desmo', completeURI: 'https://desmo.vaimee.it/' },
+          { abbreviation: 'qudt', completeURI: 'http://qudt.org/schema/qudt/' },
+          {
+            abbreviation: 'xsd',
+            completeURI: 'http://www.w3.org/2001/XMLSchema/',
+          },
+          {
+            abbreviation: 'monas',
+            completeURI: 'https://pod.dasibreaker.vaimee.it/monas/',
+          },
+        ],
+        property: { identifier: 'value', unit: 'qudt:DEG_C', datatype: 1 },
+        staticFilter: '$[?(@["type"]=="Sensor")]',
+      };
       await buyer.buyQuery(
         event.requestID,
-        'test query',
+        JSON.stringify(query),
         '0x7529d35aD28eee02De4C1B3E5f8457ecce704775',
       );
 
-      // TODO
-    });
-
-    it('should retrieve the query result from chain', async () => {
       const result = await buyer.getQueryResult();
       console.log(result);
     });

--- a/src/types/desmo-types.ts
+++ b/src/types/desmo-types.ts
@@ -6,7 +6,7 @@
  * of a published npm module use the '.ts' extension instead.
  */
 
-import { Tag } from "iexec/dist/lib/types";
+import { Tag } from 'iexec/dist/lib/types';
 
 export interface AppOrder {
   app: string;
@@ -35,5 +35,8 @@ export interface WorkerpoolOrder {
 }
 
 export enum TaskStatus {
-  COMPLETED = 'COMPLETED',
+  TASK_UPDATED = 'TASK_UPDATED',
+  TASK_COMPLETED = 'TASK_COMPLETED',
+  TASK_TIMEDOUT = 'TASK_TIMEDOUT',
+  TASK_FAILED = 'TASK_FAILED',
 }


### PR DESCRIPTION
Refactored `getQueryResult` method of the `Desmo` module. See #4 for information on the rationale behind these changes. Moving from polling to an observable mechanism (even if, internally, the iExec SDK adopts a polling strategy to update the observable).

Closes #4.