### PR TITLE
Add observable to Desmo module

### DIFF
--- a/src/types/desmo-types.ts
+++ b/src/types/desmo-types.ts
@@ -32,3 +32,8 @@ export enum TaskStatus {
   TASK_TIMEDOUT = 'TASK_TIMEDOUT',
   TASK_FAILED = 'TASK_FAILED',
 }
+
+export interface IQueryState {
+  taskID: string;
+  state: string;
+}


### PR DESCRIPTION
Adds an observable to Desmo module so that the frontend can be notified about the execution state of the query.
The observable payload contains both the taskID (it could be used by the frontend to show a link to the iExec task) and a string representing the updated status of the task.